### PR TITLE
Allow dynamic updates to bump and sharpen parameters.

### DIFF
--- a/notebooks/cdf_demonstration.ipynb
+++ b/notebooks/cdf_demonstration.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates that as the x grid resolution is increased, the CDF approaches 1.\n",
+    "It also shows that the CDF approaches 1 for bump_threshold and sharpen_alpha values of None and non-None. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qp\n",
+    "import qp_flexzboost\n",
+    "from flexcode.basis_functions import BasisCoefs\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "print(qp_flexzboost.__file__)\n",
+    "print(qp.__file__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve some real world example coefficients (i.e. weights) that are used for testing.\n",
+    "qp_flexzboost.FlexzboostGen.make_test_data()\n",
+    "coefs = qp_flexzboost.FlexzboostGen.test_data['weights']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here we defined a BasisCoefs object with bump_threshold=sharpen_threshold=None. i.e. no bump removal or peak sharpening\n",
+    "basis_coefficients = BasisCoefs(coefs,\n",
+    "                                basis_system='cosine',\n",
+    "                                z_min=0.0,\n",
+    "                                z_max=3.0,\n",
+    "                                bump_threshold=None,\n",
+    "                                sharpen_alpha=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fzb = qp.Ensemble(qp_flexzboost.flexzboost_create_from_basis_coef_object,\n",
+    "                  data=dict(weights=coefs, basis_coefficients_object=basis_coefficients))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdf_id = 6\n",
+    "x_course = np.linspace(0,3,100)\n",
+    "x_fine = np.linspace(0,3,30000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example PDF with no bump removal or peak sharpening\n",
+    "qp.plotting.plot_native(fzb[pdf_id], xlim=[0,3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate that CDFs approach 1 as grid resolution increases\n",
+    "cdf_course = fzb[pdf_id].cdf(x_course)\n",
+    "cdf_fine = fzb[pdf_id].cdf(x_fine)\n",
+    "plt.plot(x_course, np.squeeze(cdf_course), label='Course')\n",
+    "plt.plot(x_fine, np.squeeze(cdf_fine), label='Fine')\n",
+    "plt.legend()\n",
+    "\n",
+    "print('Max CDF value, course grid:', np.max(cdf_course))\n",
+    "print('Max CDF value, fine grid:', np.max(cdf_fine))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here we show that we can dynamically change the bump threshold and sharpening without rerunning the model.\n",
+    "fzb.dist.bump_threshold = 0.1\n",
+    "fzb.dist.sharpen_alpha = 1.2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdf_id = 6\n",
+    "x_course = np.linspace(0,3,100)\n",
+    "x_fine = np.linspace(0,3,30000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example PDF with bump removal and peak sharpening\n",
+    "qp.plotting.plot_native(fzb[pdf_id], xlim=[0,3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate that CDFs approach 1 as grid resolution increases\n",
+    "cdf_course = fzb[pdf_id].cdf(x_course)\n",
+    "cdf_fine = fzb[pdf_id].cdf(x_fine)\n",
+    "plt.plot(x_course, np.squeeze(cdf_course), label='Course')\n",
+    "plt.plot(x_fine, np.squeeze(cdf_fine), label='Fine')\n",
+    "plt.legend()\n",
+    "\n",
+    "print('Max CDF value, course grid:', np.max(cdf_course))\n",
+    "print('Max CDF value, fine grid:', np.max(cdf_fine))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qp_flexzboost",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -209,6 +209,28 @@
     "# Plot original, Flexzboost PDF (dashed line)\n",
     "plt.plot(x, np.squeeze(fzb[pdf_id].pdf(x)), linestyle='--')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Demonstrating that the bump threshold and sharpening alpha parameters can be changed without rerunning the model.\n",
+    "# Set the bump threshold and sharpening parameters to the original values\n",
+    "fzb.dist.bump_threshold = 0.1\n",
+    "fzb.dist.sharpen_alpha = 1.2\n",
+    "\n",
+    "# Plot original, Flexzboost PDF (dashed line)\n",
+    "plt.plot(x, np.squeeze(fzb[pdf_id].pdf(x)), linewidth=5, label='Non-None bump and sharpen parameters')\n",
+    "\n",
+    "# remove the bump threshold and sharpening parameters\n",
+    "fzb.dist.bump_threshold = None\n",
+    "fzb.dist.sharpen_alpha = None\n",
+    "\n",
+    "plt.plot(x, np.squeeze(fzb[pdf_id].pdf(x)), label='bump_threshold=sharpen_alpha=None')\n",
+    "plt.legend()"
+   ]
   }
  ],
  "metadata": {

--- a/src/qp_flexzboost/flexzboost_pdf.py
+++ b/src/qp_flexzboost/flexzboost_pdf.py
@@ -482,8 +482,8 @@ class FlexzboostGen(Pdf_rows_gen):
         """
         try:
             weights = kwargs['weights']
-        except ValueError:
-            print("Required argument `weights` was not included in kwargs")
+        except KeyError as key_error:
+            raise KeyError("Required argument `weights` was not included in kwargs") from key_error
 
         num_weights = np.shape(weights)[-1]
         return {"weights", ((npdf, num_weights), 'f4')}

--- a/src/qp_flexzboost/flexzboost_pdf.py
+++ b/src/qp_flexzboost/flexzboost_pdf.py
@@ -80,12 +80,23 @@ class FlexzboostGen(Pdf_rows_gen):
         See the method `FlexzboostGen:create_from_basis_coef_object`.
         """
 
+        # kwargs['shape'] is used to by the parent class to define the total
+        # number of PDFs stored in this generator object.
+        kwargs['shape'] = np.asarray(weights).shape[:-1]
+        super().__init__(*args, **kwargs)
+
         self._weights = np.asarray(weights)
         self._basis_system_enum_value = basis_system_enum_value
         self._z_min = z_min
         self._z_max = z_max
-        self._bump_threshold = bump_threshold
-        self._sharpen_alpha = sharpen_alpha
+        self._bump_threshold = None
+        self._sharpen_alpha = None
+
+        # These two assignments all the use of property.setter functions, which
+        # encapsulate some type checking and will also update the parent class
+        # metadata as needed.
+        self.bump_threshold = bump_threshold
+        self.sharpen_alpha = sharpen_alpha
 
         self._basis_coefficients = self._build_basis_coef_object()
 
@@ -93,10 +104,6 @@ class FlexzboostGen(Pdf_rows_gen):
         self._yvals = None
         self._ycumul = None
 
-        # kwargs['shape'] is used to by the parent class to define the total
-        # number of PDFs stored in this generator object.
-        kwargs['shape'] = self._weights.shape[:-1]
-        super().__init__(*args, **kwargs)
         self._addmetadata('basis_system_enum_value', self._basis_system_enum_value)
         self._addmetadata('z_min', self._z_min)
         self._addmetadata('z_max', self._z_max)
@@ -148,6 +155,40 @@ class FlexzboostGen(Pdf_rows_gen):
         """
         return self._bump_threshold
 
+    @bump_threshold.setter
+    def bump_threshold(self, new_bump_threshold):
+        """This is a setter for bump threshold that allows users to modify
+        the parameter on the fly without rerunning the model.
+
+        The conditional logic is a byproduct of the way that scipy will pass
+        values to the __init__ method when taking a slice of an ensemble containing
+        this generator.
+
+        `new_bump_threshold` can be passed in as a 0 dimensional
+        numpy array. For floats this is fine, but the comparison logic in Flexcode
+        breaks when a numpy 0 dimensional array (i.e. scalar) `None` value is passed in.
+        To account for this, we explicitly assign `None` when we detect a
+        None-like input.
+
+        Parameters
+        ----------
+        new_bump_threshold : float
+            The new bump threshold to use in the BasisCoefs object.
+        """
+
+        # We use the `==` comparison because Numpy will broadcast the contents
+        # of new_bump_threshold appropriately.
+        # pylint: disable-next=singleton-comparison
+        if new_bump_threshold == None:
+            self._bump_threshold = None
+        else:
+            self._bump_threshold = new_bump_threshold
+
+        # _addmetadata updates the parent class, so that slices into an ensemble
+        # will create new instances of this class with the correct values.
+        self._addmetadata('bump_threshold', self._bump_threshold)
+        self._update_basis_coef_object()
+
     @property
     def sharpen_alpha(self)->float:
         """Return the sharpen alpha used for the results stored in this object.
@@ -158,6 +199,40 @@ class FlexzboostGen(Pdf_rows_gen):
             Sharpen alpha value used to predict these results
         """
         return self._sharpen_alpha
+
+    @sharpen_alpha.setter
+    def sharpen_alpha(self, new_sharpen_alpha):
+        """This is a setter for sharpen alpha that allows users to modify
+        the parameter on the fly without rerunning the model.
+
+        The conditional logic is a byproduct of the way that scipy will pass
+        values to the __init__ method when taking a slice of an ensemble containing
+        this generator.
+
+        `new_sharpen_alpha` can be passed in as a 0 dimensional
+        numpy array. For floats this is fine, but the comparison logic in Flexcode
+        breaks when a numpy 0 dimensional array (i.e. scalar) `None` value is passed in.
+        To account for this, we explicitly assign `None` when we detect a
+        None-like input.
+
+        Parameters
+        ----------
+        new_sharpen_alpha : float
+            The new sharpen parameter to use in the BasisCoefs object.
+        """
+
+        # We use the `==` comparison because Numpy will broadcast the contents
+        # of new_sharpen_alpha appropriately.
+        # pylint: disable-next=singleton-comparison
+        if new_sharpen_alpha == None:
+            self._sharpen_alpha = None
+        else:
+            self._sharpen_alpha = new_sharpen_alpha
+
+        # _addmetadata updates the parent class, so that slices into an ensemble
+        # will create new instances of this class with the correct values.
+        self._addmetadata('sharpen_alpha', self._sharpen_alpha)
+        self._update_basis_coef_object()
 
     @property
     def basis_coefficients(self)->BasisCoefs:
@@ -185,6 +260,10 @@ class FlexzboostGen(Pdf_rows_gen):
                           z_max=self._z_max,
                           bump_threshold=self._bump_threshold,
                           sharpen_alpha=self._sharpen_alpha)
+
+    def _update_basis_coef_object(self):
+        """Simple method to update the `BasisCoefs` object 'in place'."""
+        self._basis_coefficients = self._build_basis_coef_object()
 
     def _calculate_yvals_if_needed(self, xvals:List[float]) -> None:
         """If self._yvals is None or the xvals have changed, reevaluate the y values.
@@ -255,7 +334,6 @@ class FlexzboostGen(Pdf_rows_gen):
                                         0.5 * np.add(self._yvals[:,1:],
                                                      self._yvals[:,:-1]), axis=1)
 
-#! Need to update the type hint and doc string here since x can be several different shapes
     def _pdf(self, x:List[float], row:List[int]) -> List[List[float]]:
         """Return the numerical PDFs, evaluated on the grid, `x`.
 

--- a/tests/qp_flexzboost_tests/test_flexzboost_pdf.py
+++ b/tests/qp_flexzboost_tests/test_flexzboost_pdf.py
@@ -1,41 +1,99 @@
 import numpy as np
+import pytest
 from flexcode.basis_functions import BasisCoefs
 
-from qp_flexzboost.flexzboost_pdf import FlexzboostGen
+from qp_flexzboost.flexzboost_pdf import BasisSystem, FlexzboostGen
 
+# pylint: disable=redefined-outer-name
 
-def test_initialize_flexzboost_pdf_with_basis_coef_object():
-    """Basic test to check instantiation of the FlexzboostGen object."""
+TEST_BASIS_SYSTEM = 'cosine'
+TEST_BASIS_SYSTEM_ENUM_VALUE = 1
+TEST_Z_MIN = 0.0
+TEST_Z_MAX = 3.0
+TEST_BUMP_THRESHOLD = 0.05
+TEST_SHARPEN_ALPHA = 1.2
+
+@pytest.fixture
+def flexzboost_ensemble():
+    """Pytest fixture that yields a FlexZBoost generator object"""
     test_coefs = np.ones(10, float)
-    test_basis_system = 'cosine'
-    test_z_min = 0.0
-    test_z_max = 3.0
-    test_bump_threshold = 0.05
-    test_sharpen_alpha = 1.2
+    test_basis_system = TEST_BASIS_SYSTEM
+    test_z_min = TEST_Z_MIN
+    test_z_max = TEST_Z_MAX
+    test_bump_threshold = TEST_BUMP_THRESHOLD
+    test_sharpen_alpha = TEST_SHARPEN_ALPHA
     test_basis_coef = BasisCoefs(test_coefs, test_basis_system, test_z_min,
                                  test_z_max, test_bump_threshold, test_sharpen_alpha)
 
-    test_fzb_pdf = FlexzboostGen.create_from_basis_coef_object(
+    yield FlexzboostGen.create_from_basis_coef_object(
         weights=test_coefs,
         basis_coefficients_object=test_basis_coef)
 
-    assert test_fzb_pdf is not None
+def test_initialize_flexzboost_pdf_with_basis_coef_object(flexzboost_ensemble):
+    """Basic test to check instantiation of the FlexzboostGen object."""
+    assert flexzboost_ensemble is not None
 
 def test_initialize_flexzboost_pdf_with_basis_parameters():
     """Basic test to check instantiation of the FlexzboostGen object."""
     test_coefs = np.ones(10, float)
-    test_basis_system_enum_value = 1
-    test_z_min = 0.0
-    test_z_max = 3.0
-    test_bump_threshold = 0.05
-    test_sharpen_alpha = 1.2
 
     test_fzb_pdf = FlexzboostGen(
         weights=test_coefs,
-        basis_system_enum_value=test_basis_system_enum_value,
-        z_min=test_z_min,
-        z_max=test_z_max,
-        bump_threshold=test_bump_threshold,
-        sharpen_alpha=test_sharpen_alpha)
+        basis_system_enum_value=TEST_BASIS_SYSTEM_ENUM_VALUE,
+        z_min=TEST_Z_MIN,
+        z_max=TEST_Z_MAX,
+        bump_threshold=TEST_BUMP_THRESHOLD,
+        sharpen_alpha=TEST_SHARPEN_ALPHA)
 
     assert test_fzb_pdf is not None
+
+def test_properties(flexzboost_ensemble):
+    """Basic test to ensure that getters return expected values"""
+    assert flexzboost_ensemble.dist.z_min == TEST_Z_MIN
+    assert flexzboost_ensemble.dist.z_max == TEST_Z_MAX
+    assert flexzboost_ensemble.dist.bump_threshold == TEST_BUMP_THRESHOLD
+    assert flexzboost_ensemble.dist.sharpen_alpha == TEST_SHARPEN_ALPHA
+    assert flexzboost_ensemble.dist.basis_system_enum == BasisSystem(TEST_BASIS_SYSTEM_ENUM_VALUE)
+
+    # This last assert will exercise the getting for basis_coefficients and then
+    # pull z_min off of that object and compare it to the expected value.
+    assert flexzboost_ensemble.dist.basis_coefficients.z_min == TEST_Z_MIN
+
+def test_bump_threshold_setter_with_value(flexzboost_ensemble):
+    """Basic test to exercise the bump_threshold setter for non-None values"""
+    new_bump_threshold_value = 2.5
+    flexzboost_ensemble.dist.bump_threshold = new_bump_threshold_value
+    assert flexzboost_ensemble.dist.bump_threshold == new_bump_threshold_value
+
+def test_bump_threshold_setter_with_none(flexzboost_ensemble):
+    """Basic test to exercise the bump_threshold setter for a None value"""
+    new_bump_threshold_value = None
+    flexzboost_ensemble.dist.bump_threshold = new_bump_threshold_value
+    assert flexzboost_ensemble.dist.bump_threshold == new_bump_threshold_value
+
+def test_sharpen_alpha_setter_with_value(flexzboost_ensemble):
+    """Basic test to exercise the sharpen_alpha setter for non-None values"""
+    new_sharpen_alpha_value = 3.0
+    flexzboost_ensemble.dist.sharpen_alpha = new_sharpen_alpha_value
+    assert flexzboost_ensemble.dist.sharpen_alpha == new_sharpen_alpha_value
+
+def test_sharpen_alpha_setter_with_none(flexzboost_ensemble):
+    """Basic test to exercise the sharpen_alpha setter for None values"""
+    new_sharpen_alpha_value = None
+    flexzboost_ensemble.dist.sharpen_alpha = new_sharpen_alpha_value
+    assert flexzboost_ensemble.dist.sharpen_alpha == new_sharpen_alpha_value
+
+def test_allocation_kwds(flexzboost_ensemble):
+    """Basic test to ensure that the allocation is correct"""
+    kwargs = {'weights': [0.0, 1.0]}
+    allocation_kwds = flexzboost_ensemble.dist.get_allocation_kwds(10, **kwargs)
+    assert 'weights' in allocation_kwds
+    assert ((10, 2), 'f4') in allocation_kwds
+
+def test_allocation_kwds_missing_weights(flexzboost_ensemble):
+    """Basic test to ensure that the allocation is correct"""
+    kwargs = {}
+    with pytest.raises(KeyError) as exception_info:
+        _ = flexzboost_ensemble.dist.get_allocation_kwds(10, **kwargs)
+
+    assert "Required argument `weights` was not" in str(exception_info.value)


### PR DESCRIPTION
A couple of updates were required to suppose dynamically updating bump_threshold and sharpen_alpha without having to rerun the model. 

I've included a new section in the demo notebook showing how to do this. I've also included a notebook demonstrating how the CDF representation changes based on grid resolution. 