### PR TITLE
Updating flexcode dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "FlexCode @ git+https://github.com/lee-group-cmu/FlexCode", # ! We'll want to update this dep when we finalize ownership of FlexCode.
+    "flexcode",
+    # "FlexCode @ git+https://github.com/lee-group-cmu/FlexCode", # ! We'll want to update this dep when we finalize ownership of FlexCode.
     "ipykernel", # Support for Jupyter notebooks
     "numpy >= 1.24",
     "qp-prob>=0.7.1", # The primary dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dynamic = ["version"]
 dependencies = [
     "deprecated",
     "flexcode",
-    # "FlexCode @ git+https://github.com/lee-group-cmu/FlexCode", # ! We'll want to update this dep when we finalize ownership of FlexCode.
     "ipykernel", # Support for Jupyter notebooks
     "numpy >= 1.24",
     "qp-prob>=0.7.1", # The primary dependency


### PR DESCRIPTION
Since a member of Ann Lee's group left, several years ago, there have been no updates to the flexcode version hosted on PyPI. A new version was just released with important updates, so we can now directly depend on the PyPI version. 