### PR TITLE
Updating qp dependency definition.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "flexcode",
     "ipykernel", # Support for Jupyter notebooks
     "numpy >= 1.24",
-    "qp-prob>=0.7.1", # The primary dependency
+    "qp-prob[full]>=0.8.1", # The primary dependency
     "scipy >= 1.9.0",
 ]
 


### PR DESCRIPTION
This is a quick PR in response to the change to `qp` in this PR (https://github.com/LSSTDESC/qp/pull/169) and the resulting upload of a new package version to PyPI. 

Thankfully the scheduled CI worked as intended, caught the issue and reported it quickly :) 