### PR TITLE
Update read the docs requirements so the documentation build passes.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,6 @@ jupytext
 jupyter
 matplotlib
 numpy
-qp-prob
+qp-prob[full]>=0.8.1
 qp-flexzboost
 flexcode


### PR DESCRIPTION
Updating docs/requirements.txt so that documentation build will succeed in read the docs.

After the qp dependency changed, we need to update the requirements in a few places. This is one of them that was missed in this PR: #22 